### PR TITLE
fixed memory leak in kb_storer where CMemDiskFile objects were not being freed

### DIFF
--- a/kmer_counter/kb_storer.cpp
+++ b/kmer_counter/kb_storer.cpp
@@ -70,11 +70,15 @@ void CKmerBinStorer::Release()
 	if(!files)
 		return;
 	for(int i = 0; i < n_bins; ++i)
-		if(buffer[i])
+		if(buffer[i]) 
 			delete buffer[i];
 
 	delete[] buffer;
 	buffer = NULL;	
+
+	for(int i = 0; i < n_bins; ++i)
+	  if(files[i])
+	    delete files[i];
 
 	delete[] files;
 	files = NULL;


### PR DESCRIPTION
fixed memory leak in kb_storer where CMemDiskFile objects were not being freed.
@marekkokot 