### PR TITLE
avoid redefinition

### DIFF
--- a/kmc_api/kmer_defs.h
+++ b/kmc_api/kmer_defs.h
@@ -15,7 +15,9 @@
 #define KMC_VER		"3.1.0"
 #define KMC_DATE	"2018-05-10"
 
+#ifndef MIN
 #define MIN(x,y)	((x) < (y) ? (x) : (y))
+#endif
 
 #ifndef WIN32
 	#include <stdint.h>


### PR DESCRIPTION
Fix a warning on MacOS

```
In file included from /Users/.../KMC/kmc_api/kmc_file.h:14,
                 from /Users/....cpp:6:
/Users/.../KMC/kmc_api/kmer_defs.h:18: error: "MIN" redefined [-Werror]
 #define MIN(x,y) ((x) < (y) ? (x) : (y))
```