### PR TITLE
Update `const` qualifications in `kmc_api`

### DIFF
--- a/kmc_api/kmc_file.cpp
+++ b/kmc_api/kmc_file.cpp
@@ -307,7 +307,7 @@ bool CKMCFile::ReadParamsFrom_prefix_file_buf(uint64 &size)
 // OUT: count - kmer's counter if kmer exists
 // RET: true  - if kmer exists
 //------------------------------------------------------------------------------------------
-bool CKMCFile::CheckKmer(CKmerAPI &kmer, float &count) const
+bool CKMCFile::CheckKmer(const CKmerAPI &kmer, float &count) const
 {
 	uint32 int_counter;
 	if (CheckKmer(kmer, int_counter))
@@ -327,7 +327,7 @@ bool CKMCFile::CheckKmer(CKmerAPI &kmer, float &count) const
 // OUT: count - kmer's counter if kmer exists
 // RET: true  - if kmer exists
 //------------------------------------------------------------------------------------------
-bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint32 &count) const
+bool CKMCFile::CheckKmer(const CKmerAPI &kmer, uint32 &count) const
 {
 	if(is_opened != opened_for_RA)
 		return false;
@@ -371,7 +371,7 @@ bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint32 &count) const
 // OUT: count - kmer's counter if kmer exists
 // RET: true  - if kmer exists
 //------------------------------------------------------------------------------------------
-bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint64 &count) const
+bool CKMCFile::CheckKmer(const CKmerAPI &kmer, uint64 &count) const
 {
 	if (is_opened != opened_for_RA)
 		return false;
@@ -772,7 +772,7 @@ uint32 CKMCFile::KmerLength(void) const
 // IN	: kmer - kmer
 // RET	: true if kmer exists
 //----------------------------------------------------------------------------------------
-bool CKMCFile::IsKmer(CKmerAPI &kmer) const
+bool CKMCFile::IsKmer(const CKmerAPI &kmer) const
 {
 	uint32 _count;
 	if(CheckKmer(kmer, _count))
@@ -964,7 +964,7 @@ bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<float>& c
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-uint32 CKMCFile::count_for_kmer_kmc1(CKmerAPI& kmer) const
+uint32 CKMCFile::count_for_kmer_kmc1(const CKmerAPI& kmer) const
 {
 	//recognize a prefix:
 
@@ -989,7 +989,7 @@ uint32 CKMCFile::count_for_kmer_kmc1(CKmerAPI& kmer) const
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-uint32 CKMCFile::count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos) const
+uint32 CKMCFile::count_for_kmer_kmc2(const CKmerAPI& kmer, uint32 bin_start_pos) const
 {
 	//recognize a prefix:
 	uint64 pattern_prefix_value = kmer.kmer_data[0];

--- a/kmc_api/kmc_file.cpp
+++ b/kmc_api/kmc_file.cpp
@@ -307,7 +307,7 @@ bool CKMCFile::ReadParamsFrom_prefix_file_buf(uint64 &size)
 // OUT: count - kmer's counter if kmer exists
 // RET: true  - if kmer exists
 //------------------------------------------------------------------------------------------
-bool CKMCFile::CheckKmer(CKmerAPI &kmer, float &count)
+bool CKMCFile::CheckKmer(CKmerAPI &kmer, float &count) const
 {
 	uint32 int_counter;
 	if (CheckKmer(kmer, int_counter))
@@ -327,7 +327,7 @@ bool CKMCFile::CheckKmer(CKmerAPI &kmer, float &count)
 // OUT: count - kmer's counter if kmer exists
 // RET: true  - if kmer exists
 //------------------------------------------------------------------------------------------
-bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint32 &count)
+bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint32 &count) const
 {
 	if(is_opened != opened_for_RA)
 		return false;
@@ -371,7 +371,7 @@ bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint32 &count)
 // OUT: count - kmer's counter if kmer exists
 // RET: true  - if kmer exists
 //------------------------------------------------------------------------------------------
-bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint64 &count)
+bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint64 &count) const
 {
 	if (is_opened != opened_for_RA)
 		return false;
@@ -410,7 +410,7 @@ bool CKMCFile::CheckKmer(CKmerAPI &kmer, uint64 &count)
 // Check if end of file
 // RET: true - all kmers are listed
 //-----------------------------------------------------------------------------------------------
-bool CKMCFile::Eof(void)
+bool CKMCFile::Eof(void) const
 {
 	return end_of_file;	
 }
@@ -707,7 +707,7 @@ bool CKMCFile::SetMinCount(uint32 x)
 // Return a value of min_count. Kmers with counters below this theshold are ignored 
 // RET	: a value of min_count
 //----------------------------------------------------------------------------------------
-uint32 CKMCFile::GetMinCount(void)
+uint32 CKMCFile::GetMinCount(void) const
 {
 	return min_count;
 }
@@ -733,7 +733,7 @@ bool CKMCFile::SetMaxCount(uint32 x)
 // Return a value of max_count. Kmers with counters above this theshold are ignored 
 // RET	: a value of max_count
 //----------------------------------------------------------------------------------------
-uint64 CKMCFile::GetMaxCount(void)
+uint64 CKMCFile::GetMaxCount(void) const
 {
 	return max_count;
 }
@@ -742,7 +742,7 @@ uint64 CKMCFile::GetMaxCount(void)
 // Return true if KMC was run without -b switch
 // RET	: a value of both_strands
 //----------------------------------------------------------------------------------------
-bool CKMCFile::GetBothStrands(void)
+bool CKMCFile::GetBothStrands(void) const
 {
 	return both_strands;
 }
@@ -762,7 +762,7 @@ void CKMCFile::ResetMinMaxCounts(void)
 // Return the length of kmers
 // RET	: the length of kmers
 //----------------------------------------------------------------------------------------
-uint32 CKMCFile::KmerLength(void)
+uint32 CKMCFile::KmerLength(void) const
 {
 	return kmer_length;			
 }
@@ -772,7 +772,7 @@ uint32 CKMCFile::KmerLength(void)
 // IN	: kmer - kmer
 // RET	: true if kmer exists
 //----------------------------------------------------------------------------------------
-bool CKMCFile::IsKmer(CKmerAPI &kmer)
+bool CKMCFile::IsKmer(CKmerAPI &kmer) const
 {
 	uint32 _count;
 	if(CheckKmer(kmer, _count))
@@ -852,7 +852,7 @@ uint64 CKMCFile::KmerCount(void)
 //			_total_kmers	- the total number of kmers
 // RET	: true if kmer_database has been opened
 //---------------------------------------------------------------------------------
-bool CKMCFile::Info(uint32 &_kmer_length, uint32 &_mode, uint32 &_counter_size, uint32 &_lut_prefix_length, uint32 &_signature_len, uint32 &_min_count, uint64 &_max_count, uint64 &_total_kmers)
+bool CKMCFile::Info(uint32 &_kmer_length, uint32 &_mode, uint32 &_counter_size, uint32 &_lut_prefix_length, uint32 &_signature_len, uint32 &_min_count, uint64 &_max_count, uint64 &_total_kmers) const
 {
 	if(is_opened)
 	{
@@ -873,7 +873,7 @@ bool CKMCFile::Info(uint32 &_kmer_length, uint32 &_mode, uint32 &_counter_size, 
 }
 
 // Get current parameters from kmer_database
-bool CKMCFile::Info(CKMCFileInfo& info)
+bool CKMCFile::Info(CKMCFileInfo& info) const
 {
 	if (is_opened)
 	{
@@ -901,7 +901,7 @@ bool CKMCFile::Info(CKMCFileInfo& info)
 // IN   :   read			- 
 // RET	:   true if success, false if k > read length or some failure 
 //---------------------------------------------------------------------------------
-bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<uint32>& counters)
+bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<uint32>& counters) const
 {
 	if (is_opened != opened_for_RA)
 		return false;
@@ -936,7 +936,7 @@ bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<uint32>& 
 // IN   :   read			- 
 // RET	: true if success
 //---------------------------------------------------------------------------------
-bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<float>& counters)
+bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<float>& counters) const
 {
 	if (is_opened != opened_for_RA)
 		return false;
@@ -964,7 +964,7 @@ bool CKMCFile::GetCountersForRead(const std::string& read, std::vector<float>& c
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-uint32 CKMCFile::count_for_kmer_kmc1(CKmerAPI& kmer)
+uint32 CKMCFile::count_for_kmer_kmc1(CKmerAPI& kmer) const
 {
 	//recognize a prefix:
 
@@ -989,7 +989,7 @@ uint32 CKMCFile::count_for_kmer_kmc1(CKmerAPI& kmer)
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-uint32 CKMCFile::count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos)
+uint32 CKMCFile::count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos) const
 {
 	//recognize a prefix:
 	uint64 pattern_prefix_value = kmer.kmer_data[0];
@@ -1013,7 +1013,7 @@ uint32 CKMCFile::count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos)
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-bool CKMCFile::GetCountersForRead_kmc1_both_strands(const std::string& read, std::vector<uint32>& counters)
+bool CKMCFile::GetCountersForRead_kmc1_both_strands(const std::string& read, std::vector<uint32>& counters) const
 {
 	uint32 read_len = static_cast<uint32>(read.length());
 	counters.resize(read.length() - kmer_length + 1);
@@ -1091,7 +1091,7 @@ bool CKMCFile::GetCountersForRead_kmc1_both_strands(const std::string& read, std
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-bool CKMCFile::GetCountersForRead_kmc1(const std::string& read, std::vector<uint32>& counters)
+bool CKMCFile::GetCountersForRead_kmc1(const std::string& read, std::vector<uint32>& counters) const
 {	
 	uint32 read_len = static_cast<uint32>(read.length());
 	counters.resize(read.length() - kmer_length + 1);
@@ -1155,7 +1155,7 @@ bool CKMCFile::GetCountersForRead_kmc1(const std::string& read, std::vector<uint
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-void CKMCFile::GetSuperKmers(const std::string& transformed_read, super_kmers_t& super_kmers)
+void CKMCFile::GetSuperKmers(const std::string& transformed_read, super_kmers_t& super_kmers) const
 {
 	uint32 i = 0;
 	uint32 len = 0; //length of super k-mer
@@ -1244,7 +1244,7 @@ void CKMCFile::GetSuperKmers(const std::string& transformed_read, super_kmers_t&
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-bool CKMCFile::GetCountersForRead_kmc2_both_strands(const std::string& read, std::vector<uint32>& counters)
+bool CKMCFile::GetCountersForRead_kmc2_both_strands(const std::string& read, std::vector<uint32>& counters) const
 {
 	counters.resize(read.length() - kmer_length + 1);
 	std::string transformed_read = read;
@@ -1316,7 +1316,7 @@ bool CKMCFile::GetCountersForRead_kmc2_both_strands(const std::string& read, std
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-bool CKMCFile::GetCountersForRead_kmc2(const std::string& read, std::vector<uint32>& counters)
+bool CKMCFile::GetCountersForRead_kmc2(const std::string& read, std::vector<uint32>& counters) const
 {	
 	counters.resize(read.length() - kmer_length + 1);
 	std::string transformed_read = read;
@@ -1380,7 +1380,7 @@ bool CKMCFile::GetCountersForRead_kmc2(const std::string& read, std::vector<uint
 //---------------------------------------------------------------------------------
 // Auxiliary function.
 //---------------------------------------------------------------------------------
-bool CKMCFile::BinarySearch(int64 index_start, int64 index_stop, const CKmerAPI& kmer, uint64& counter, uint32 pattern_offset)
+bool CKMCFile::BinarySearch(int64 index_start, int64 index_stop, const CKmerAPI& kmer, uint64& counter, uint32 pattern_offset) const
 {
 	if (index_start >= static_cast<int64>(total_kmers))
 		return false;

--- a/kmc_api/kmc_file.h
+++ b/kmc_api/kmc_file.h
@@ -70,34 +70,33 @@ class CKMCFile
 	uint64 original_max_count;
 
 	static uint64 part_size; // the size of a block readed to sufix_file_buf, in listing mode 
-	
-	bool BinarySearch(int64 index_start, int64 index_stop, const CKmerAPI& kmer, uint64& counter, uint32 pattern_offset);
+
+	bool BinarySearch(int64 index_start, int64 index_stop, const CKmerAPI& kmer, uint64& counter, uint32 pattern_offset) const;
 
 	// Open a file, recognize its size and check its marker. Auxiliary function.
 	bool OpenASingleFile(const std::string &file_name, FILE *&file_handler, uint64 &size, char marker[]);	
 
 	// Recognize current parameters. Auxiliary function.
-	bool ReadParamsFrom_prefix_file_buf(uint64 &size);	
+	bool ReadParamsFrom_prefix_file_buf(uint64 &size);
 
 	// Reload a contents of an array "sufix_file_buf" for listing mode. Auxiliary function. 
 	void Reload_sufix_file_buf();
 
 	// Implementation of GetCountersForRead for kmc1 database format for both strands
-	bool GetCountersForRead_kmc1_both_strands(const std::string& read, std::vector<uint32>& counters);
+	bool GetCountersForRead_kmc1_both_strands(const std::string& read, std::vector<uint32>& counters) const;
 
 	// Implementation of GetCountersForRead for kmc1 database format without choosing canonical k-mer
-	bool GetCountersForRead_kmc1(const std::string& read, std::vector<uint32>& counters);		
+	bool GetCountersForRead_kmc1(const std::string& read, std::vector<uint32>& counters) const;
 
 	using super_kmers_t = std::vector<std::tuple<uint32, uint32, uint32>>;//start_pos, len, bin_no
-	void GetSuperKmers(const std::string& transformed_read, super_kmers_t& super_kmers);
+	void GetSuperKmers(const std::string& transformed_read, super_kmers_t& super_kmers)  const;
 
 	// Implementation of GetCountersForRead for kmc2 database format for both strands
-	bool GetCountersForRead_kmc2_both_strands(const std::string& read, std::vector<uint32>& counters);
+	bool GetCountersForRead_kmc2_both_strands(const std::string& read, std::vector<uint32>& counters) const;
 
 	// Implementation of GetCountersForRead for kmc2 database format
-	bool GetCountersForRead_kmc2(const std::string& read, std::vector<uint32>& counters);
+	bool GetCountersForRead_kmc2(const std::string& read, std::vector<uint32>& counters) const;
 public:
-		
 	CKMCFile();
 	~CKMCFile();
 
@@ -120,54 +119,54 @@ public:
 	bool SetMinCount(uint32 x);
 
 	// Return a value of min_count. Kmers with counters below this theshold are ignored 
-	uint32 GetMinCount(void);
+	uint32 GetMinCount(void) const;
 
 	// Set the maximal value for a counter. Kmers with counters above this theshold are ignored
 	bool SetMaxCount(uint32 x);
 
 	// Return a value of max_count. Kmers with counters above this theshold are ignored 
-	uint64 GetMaxCount(void);
+	uint64 GetMaxCount(void) const;
 	
 	//Return true if kmc was run without -b switch.
-	bool GetBothStrands(void);
+	bool GetBothStrands(void) const;
 
 	// Return the total number of kmers between min_count and max_count
 	uint64 KmerCount(void);
 
 	// Return the length of kmers
-	uint32 KmerLength(void);
+	uint32 KmerLength(void) const;
 
 	// Set initial values to enable listing kmers from the begining. Only in listing mode
 	bool RestartListing(void);
 
 	// Return true if all kmers are listed
-	bool Eof(void);
+	bool Eof(void) const;
 
 	// Return true if kmer exists. In this case return kmer's counter in count
-	bool CheckKmer(CKmerAPI &kmer, float &count);
+	bool CheckKmer(CKmerAPI &kmer, float &count) const;
 
-	bool CheckKmer(CKmerAPI &kmer, uint32 &count);
+	bool CheckKmer(CKmerAPI &kmer, uint32 &count) const;
 
-	bool CheckKmer(CKmerAPI &kmer, uint64 &count);
+	bool CheckKmer(CKmerAPI &kmer, uint64 &count) const;
 
 	// Return true if kmer exists
-	bool IsKmer(CKmerAPI &kmer);
+	bool IsKmer(CKmerAPI &kmer) const;
 
 	// Set original (readed from *.kmer_pre) values for min_count and max_count
 	void ResetMinMaxCounts(void);
 
 	// Get current parameters from kmer_database
-	bool Info(uint32 &_kmer_length, uint32 &_mode, uint32 &_counter_size, uint32 &_lut_prefix_length, uint32 &_signature_len, uint32 &_min_count, uint64 &_max_count, uint64 &_total_kmers);
+	bool Info(uint32 &_kmer_length, uint32 &_mode, uint32 &_counter_size, uint32 &_lut_prefix_length, uint32 &_signature_len, uint32 &_min_count, uint64 &_max_count, uint64 &_total_kmers) const;
 	
 	// Get current parameters from kmer_database
-	bool Info(CKMCFileInfo& info);
+	bool Info(CKMCFileInfo& info) const;
 
 	// Get counters for all k-mers in read
-	bool GetCountersForRead(const std::string& read, std::vector<uint32>& counters);
-	bool GetCountersForRead(const std::string& read, std::vector<float>& counters);
+	bool GetCountersForRead(const std::string& read, std::vector<uint32>& counters) const;
+	bool GetCountersForRead(const std::string& read, std::vector<float>& counters) const;
 	private:
-		uint32 count_for_kmer_kmc1(CKmerAPI& kmer);
-		uint32 count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos);
+		uint32 count_for_kmer_kmc1(CKmerAPI& kmer) const;
+		uint32 count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos) const;
 };
 
 #endif

--- a/kmc_api/kmc_file.h
+++ b/kmc_api/kmc_file.h
@@ -143,14 +143,14 @@ public:
 	bool Eof(void) const;
 
 	// Return true if kmer exists. In this case return kmer's counter in count
-	bool CheckKmer(CKmerAPI &kmer, float &count) const;
+	bool CheckKmer(const CKmerAPI &kmer, float &count) const;
 
-	bool CheckKmer(CKmerAPI &kmer, uint32 &count) const;
+	bool CheckKmer(const CKmerAPI &kmer, uint32 &count) const;
 
-	bool CheckKmer(CKmerAPI &kmer, uint64 &count) const;
+	bool CheckKmer(const CKmerAPI &kmer, uint64 &count) const;
 
 	// Return true if kmer exists
-	bool IsKmer(CKmerAPI &kmer) const;
+	bool IsKmer(const CKmerAPI &kmer) const;
 
 	// Set original (readed from *.kmer_pre) values for min_count and max_count
 	void ResetMinMaxCounts(void);
@@ -165,8 +165,8 @@ public:
 	bool GetCountersForRead(const std::string& read, std::vector<uint32>& counters) const;
 	bool GetCountersForRead(const std::string& read, std::vector<float>& counters) const;
 	private:
-		uint32 count_for_kmer_kmc1(CKmerAPI& kmer) const;
-		uint32 count_for_kmer_kmc2(CKmerAPI& kmer, uint32 bin_start_pos) const;
+		uint32 count_for_kmer_kmc1(const CKmerAPI& kmer) const;
+		uint32 count_for_kmer_kmc2(const CKmerAPI& kmer, uint32 bin_start_pos) const;
 };
 
 #endif

--- a/kmc_api/kmer_api.h
+++ b/kmc_api/kmer_api.h
@@ -46,12 +46,12 @@ protected:
 		kmer_data[(pos + byte_alignment) >> 5] += (uint64)val << (62 - (((pos + byte_alignment) & 31) * 2));
 	}
 
-	inline uchar extract2bits(uint32 pos)
+	inline uchar extract2bits(uint32 pos) const
 	{
 		return (kmer_data[(pos + byte_alignment) >> 5] >> (62 - (((pos + byte_alignment) & 31) * 2))) & 3;
 	}
 	//----------------------------------------------------------------------------------
-	inline void SHL_insert2bits(uchar val)
+	inline void SHL_insert2bits(uchar val) const
 	{
 		kmer_data[0] <<= 2;
 		if (byte_alignment)
@@ -68,7 +68,7 @@ protected:
 	}
 	
 	//----------------------------------------------------------------------------------
-	inline void SHR_insert2bits(uchar val)
+	inline void SHR_insert2bits(uchar val) const
 	{
 		for (uint32 i = no_of_rows - 1; i > 0; --i)
 		{
@@ -98,7 +98,7 @@ protected:
 
 	// ----------------------------------------------------------------------------------
 	template<typename RandomAccessIterator>
-	inline void to_string_impl(RandomAccessIterator iter)
+	inline void to_string_impl(RandomAccessIterator iter) const
 	{
 		uchar *byte_ptr;
 		uchar c;
@@ -391,7 +391,7 @@ public:
 // IN	: pos - a position of a symbol
 // RET	: symbol - a symbol placed on a position pos
 //-----------------------------------------------------------------------
-	inline char get_asci_symbol(unsigned int pos)
+	inline char get_asci_symbol(unsigned int pos) const
 	{
 		if(pos >= kmer_length)
 			return 0;
@@ -411,7 +411,7 @@ public:
 	// IN	: pos - a position of a symbol
 	// RET	: symbol - a symbol placed on a position pos
 	//-----------------------------------------------------------------------
-	inline uchar get_num_symbol(unsigned int pos)
+	inline uchar get_num_symbol(unsigned int pos) const
 	{
 		if (pos >= kmer_length)
 			return 0;
@@ -430,7 +430,7 @@ public:
 	// Convert kmer into string (an alphabet ACGT)
 	// RET	: string kmer
 	//-----------------------------------------------------------------------
-	inline std::string to_string()
+	inline std::string to_string() const
 	{
 		std::string string_kmer;		
 		string_kmer.resize(kmer_length);
@@ -441,14 +441,14 @@ public:
 	// Convert kmer into string (an alphabet ACGT). The function assumes enough memory was allocated
 	// OUT	: str - string kmer. 
 	//-----------------------------------------------------------------------
-	inline void to_string(char *str)
+	inline void to_string(char *str) const
 	{
 		to_string_impl(str);
 		str[kmer_length] = '\0';
 	};
 
 
-	inline void to_long(std::vector<uint64>& kmer)
+	inline void to_long(std::vector<uint64>& kmer) const
 	{
 		kmer.resize(no_of_rows);
 		uint32 offset = 62 - ((kmer_length - 1 + byte_alignment) & 31) * 2;
@@ -472,7 +472,7 @@ public:
 	// Convert kmer into string (an alphabet ACGT)
 	// OUT 	: str - string kmer
 	//-----------------------------------------------------------------------
-	inline void to_string(std::string &str)
+	inline void to_string(std::string &str) const
 	{	
 		str.resize(kmer_length);
 		to_string_impl(str.begin());
@@ -650,7 +650,7 @@ public:
 // IN	: sig_len	- the length of a signature
 // RET	: signature value
 //-----------------------------------------------------------------------
-	 uint32 get_signature(uint32 sig_len)
+	 uint32 get_signature(uint32 sig_len) const
 	 {
 		 uchar symb;
 		 CMmer cur_mmr(sig_len);

--- a/kmc_api/kmer_defs.h
+++ b/kmc_api/kmer_defs.h
@@ -35,7 +35,6 @@
 
 
 	#include <stdio.h>
-	#include <ext/algorithm>
 	#include <iostream>
 
 #else


### PR DESCRIPTION
The code becomes more understandable, the compiler can easier optimize the code.
Further on, it will look more natural in the [rust bindings `kmc-rs`](https://github.com/EQt/kmc-rs) to KMC's API.
