### PR TITLE
Fix missing includes

### DIFF
--- a/kmc_api/kmer_api.h
+++ b/kmc_api/kmer_api.h
@@ -14,6 +14,7 @@ Date   : 2023-03-10
 
 #include "kmer_defs.h"
 #include <string>
+#include <cstring>
 #include <iostream>
 #include <vector>
 #include "mmer.h"

--- a/kmc_core/queues.h
+++ b/kmc_core/queues.h
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <thread>
 #include <mutex>
+#include <algorithm>
 
 using namespace std;
 


### PR DESCRIPTION
I needed these additional includes to compile for x86_64-w64-mingw32.

See https://github.com/JuliaPackaging/Yggdrasil/pull/6655