### PR TITLE
Fix header dependency issues when building with GCC 13

### DIFF
--- a/kmc_core/kff_writer.h
+++ b/kmc_core/kff_writer.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 template<typename T>
 void StoreBigEndian(uint8_t* buff, const T& data)

--- a/kmc_tools/kff_info_reader.cpp
+++ b/kmc_tools/kff_info_reader.cpp
@@ -6,6 +6,7 @@
 //#include <iostream>
 #include <algorithm>
 #include <cstring>
+#include <cstdint>
 
 std::string CKFFInfoReader::ReadVarName()
 {

--- a/kmc_tools/kff_info_reader.h
+++ b/kmc_tools/kff_info_reader.h
@@ -4,6 +4,7 @@
 #include <limits>
 #include <string>
 #include <map>
+#include <cstdint>
 
 
 template<typename T>


### PR DESCRIPTION
Fixes building KMC with GCC 13 which currently fails because of a missing `#include <cstdint>` in several files (see "Header dependency" in https://gcc.gnu.org/gcc-13/porting_to.html for the why).